### PR TITLE
resolves #68 show uncovered time also as "rounded" in activity report

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,7 +83,8 @@ dependencies {
     implementation(kotlin("stdlib-jdk8"))
 
     testImplementation("commons-io:commons-io:2.8.0")
-    testImplementation("org.mockito:mockito-core:3.12.4")
+    testImplementation("org.mockito:mockito-core:4.5.1")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:4.1.0")
     testImplementation("org.assertj:assertj-core:3.18.1")
     testImplementation("junit:junit-dep:4.11")
 }

--- a/src/main/kotlin/org/stt/cli/CLIApplication.kt
+++ b/src/main/kotlin/org/stt/cli/CLIApplication.kt
@@ -8,11 +8,12 @@ import org.stt.config.ConfigServiceFacade
 import org.stt.persistence.BackupCreator
 import org.stt.persistence.stt.STTPersistenceModule
 import org.stt.text.TextModule
+import org.stt.time.TimeUtilModule
 
 import javax.inject.Singleton
 
 @Singleton
-@Component(modules = [STTPersistenceModule::class, ConfigModule::class, BaseModule::class, TextModule::class, CommandModule::class])
+@Component(modules = [STTPersistenceModule::class, ConfigModule::class, BaseModule::class, TextModule::class, CommandModule::class, TimeUtilModule::class])
 interface CLIApplication {
     fun backupCreator(): BackupCreator
 

--- a/src/main/kotlin/org/stt/cli/ReportPrinter.kt
+++ b/src/main/kotlin/org/stt/cli/ReportPrinter.kt
@@ -14,6 +14,7 @@ import org.stt.reporting.WorkingtimeItemProvider
 import org.stt.text.ItemCategorizer
 import org.stt.text.ItemCategorizer.ItemCategory
 import org.stt.time.DateTimes
+import org.stt.time.DurationRounder
 import org.stt.time.until
 import java.io.PrintStream
 import java.time.Duration
@@ -28,7 +29,8 @@ class ReportPrinter @Inject
 constructor(private val queries: TimeTrackingItemQueries,
             private val configuration: CliConfig,
             private val workingtimeItemProvider: WorkingtimeItemProvider,
-            private val categorizer: ItemCategorizer) {
+            private val categorizer: ItemCategorizer,
+            private val rounder: DurationRounder) {
 
     fun report(args: MutableCollection<String>, printTo: PrintStream) {
         var searchString: String? = null
@@ -133,7 +135,7 @@ constructor(private val queries: TimeTrackingItemQueries,
         criteria.withStartBetween(reportStart!! until reportEnd)
 
         queries.queryItems(criteria).use { itemsToConsider ->
-            val reporter = SummingReportGenerator(itemsToConsider, categorizer )
+            val reporter = SummingReportGenerator(itemsToConsider, categorizer, rounder )
             val report = reporter.createReport()
 
             if (DateTimes.isToday(reportStart)) {
@@ -153,17 +155,17 @@ constructor(private val queries: TimeTrackingItemQueries,
 
             var worktimeDuration = Duration.ZERO
             var breakTimeDuration = Duration.ZERO
-            for ((duration, comment) in reportingItems) {
+            for (reportItem in reportingItems) {
                 var prefix = " "
-                if (ItemCategory.BREAK == categorizer.getCategory(comment)) {
+                if (ItemCategory.BREAK == categorizer.getCategory(reportItem.comment)) {
                     prefix = "*"
-                    breakTimeDuration = breakTimeDuration.plus(duration)
+                    breakTimeDuration = breakTimeDuration.plus(reportItem.duration)
                 } else {
-                    worktimeDuration = worktimeDuration.plus(duration)
+                    worktimeDuration = worktimeDuration.plus(reportItem.duration)
                 }
                 printTruncatedString(
-                        prefix + DateTimes.prettyPrintDuration(duration)
-                                + "   " + comment, printTo, truncateLongLines)
+                        prefix + DateTimes.prettyPrintDuration(reportItem.duration)
+                                + "   " + reportItem.comment, printTo, truncateLongLines)
             }
 
             printTo.println("====== overall sum: ======")

--- a/src/main/kotlin/org/stt/cli/ReportPrinter.kt
+++ b/src/main/kotlin/org/stt/cli/ReportPrinter.kt
@@ -155,17 +155,17 @@ constructor(private val queries: TimeTrackingItemQueries,
 
             var worktimeDuration = Duration.ZERO
             var breakTimeDuration = Duration.ZERO
-            for (reportItem in reportingItems) {
+            for ((duration, _, comment) in reportingItems) {
                 var prefix = " "
-                if (ItemCategory.BREAK == categorizer.getCategory(reportItem.comment)) {
+                if (ItemCategory.BREAK == categorizer.getCategory(comment)) {
                     prefix = "*"
-                    breakTimeDuration = breakTimeDuration.plus(reportItem.duration)
+                    breakTimeDuration = breakTimeDuration.plus(duration)
                 } else {
-                    worktimeDuration = worktimeDuration.plus(reportItem.duration)
+                    worktimeDuration = worktimeDuration.plus(duration)
                 }
                 printTruncatedString(
-                        prefix + DateTimes.prettyPrintDuration(reportItem.duration)
-                                + "   " + reportItem.comment, printTo, truncateLongLines)
+                        prefix + DateTimes.prettyPrintDuration(duration)
+                                + "   " + comment, printTo, truncateLongLines)
             }
 
             printTo.println("====== overall sum: ======")

--- a/src/main/kotlin/org/stt/gui/jfx/binding/ReportBinding.kt
+++ b/src/main/kotlin/org/stt/gui/jfx/binding/ReportBinding.kt
@@ -12,6 +12,7 @@ import org.stt.query.TimeTrackingItemQueries
 import org.stt.reporting.SummingReportGenerator
 import org.stt.reporting.SummingReportGenerator.Report
 import org.stt.text.ItemCategorizer
+import org.stt.time.DurationRounder
 import org.stt.time.until
 import java.time.Duration
 import java.time.LocalDate
@@ -19,6 +20,7 @@ import java.time.LocalDate
 class ReportBinding(val reportStart: ObservableValue<LocalDate>,
                     val reportEnd: ObservableValue<LocalDate>,
                     val itemCategorizer: ItemCategorizer,
+                    val rounder: DurationRounder,
                     val queries: TimeTrackingItemQueries) : ObjectBinding<Report>() {
 
     init {
@@ -30,12 +32,12 @@ class ReportBinding(val reportStart: ObservableValue<LocalDate>,
                     null && reportEnd.value != null) {
                 createSummaryReportFor()
             } else {
-                Report(emptyList(), null, null, Duration.ZERO)
+                Report(emptyList(), null, null, Duration.ZERO, Duration.ZERO)
             }
 
     private fun createSummaryReportFor(): Report {
         val criteria = Criteria()
         criteria.withStartBetween(reportStart.value.atStartOfDay() until reportEnd.value.atStartOfDay())
-        queries.queryItems(criteria).use { items -> return SummingReportGenerator(items, itemCategorizer).createReport() }
+        queries.queryItems(criteria).use { items -> return SummingReportGenerator(items, itemCategorizer, rounder).createReport() }
     }
 }

--- a/src/main/kotlin/org/stt/model/ReportingItem.kt
+++ b/src/main/kotlin/org/stt/model/ReportingItem.kt
@@ -3,6 +3,6 @@ package org.stt.model
 
 import java.time.Duration
 
-data class ReportingItem(val duration: Duration, val comment: String, val isBreak: Boolean) {
+data class ReportingItem(val duration: Duration, val roundedDuration: Duration, val comment: String, val isBreak: Boolean) {
     override fun toString() = "$duration $comment ${if (isBreak) "(break)" else ""}"
 }

--- a/src/main/kotlin/org/stt/time/DurationRounder.kt
+++ b/src/main/kotlin/org/stt/time/DurationRounder.kt
@@ -7,8 +7,8 @@ import javax.inject.Singleton
 @Singleton
 class DurationRounder {
 
-    private var intervalMillis: Long = 0
-    private var tieBreakMillis: Long = 0
+    private var intervalMillis: Long = 1
+    private var tieBreakMillis: Long = 1
 
     fun setInterval(interval: Duration) {
         intervalMillis = interval.toMillis()

--- a/src/main/resources/org/stt/gui/jfx/ReportPanel.fxml
+++ b/src/main/resources/org/stt/gui/jfx/ReportPanel.fxml
@@ -43,21 +43,21 @@
                                 <Font name="System Bold" size="12.0" />
                             </font>
                         </Label>
-                        <Label fx:id="roundedDurationTime" text="roundedDurationTime" GridPane.columnIndex="1" GridPane.columnSpan="3" />
+                        <Label fx:id="totalDuration" text="totalDuration" GridPane.columnIndex="1" GridPane.columnSpan="3" />
                         <!-- -->
                         <Label text="%report.nonEffectiveTime" GridPane.rowIndex="1">
                             <font>
                                 <Font name="System Bold" size="12.0" />
                             </font>
                         </Label>
-                        <Label fx:id="nonEffectiveTime" text="nonEffectiveTime" GridPane.columnIndex="2" GridPane.columnSpan="2" GridPane.rowIndex="1" />
+                        <Label fx:id="nonEffectiveDuration" text="nonEffectiveDuration" GridPane.columnIndex="2" GridPane.columnSpan="2" GridPane.rowIndex="1" />
                         <!-- -->
                         <Label text="%report.uncoveredTime" GridPane.rowIndex="2">
                             <font>
                                 <Font name="System Bold" size="12.0" />
                             </font>
                         </Label>
-                        <Label fx:id="uncoveredTime" text="uncoveredTime" GridPane.columnIndex="3" GridPane.rowIndex="2" />
+                        <Label fx:id="uncoveredDuration" text="uncoveredDuration" GridPane.columnIndex="3" GridPane.rowIndex="2" />
                         <!-- -->
 
 
@@ -66,14 +66,14 @@
                                 <Font name="System Bold" size="12.0" />
                             </font>
                         </Label>
-                        <Label fx:id="breakTime" text="breakTime" GridPane.columnIndex="3" GridPane.rowIndex="3" />
+                        <Label fx:id="breakDuration" text="breakDuration" GridPane.columnIndex="3" GridPane.rowIndex="3" />
 
                         <Label text="%report.effectiveDurationTime" GridPane.rowIndex="4">
                             <font>
                                 <Font name="System Bold" size="12.0" />
                             </font>
                         </Label>
-                        <Label fx:id="effectiveDurationTime" text="effectiveDurationTime" GridPane.columnIndex="2" GridPane.columnSpan="2" GridPane.rowIndex="4" />
+                        <Label fx:id="effectiveDuration" text="effectiveDuration" GridPane.columnIndex="2" GridPane.columnSpan="2" GridPane.rowIndex="4" />
                         <!-- -->
                         <Label text="%report.startOfReport" GridPane.rowIndex="6">
                             <font>

--- a/src/test/kotlin/org/stt/cli/MainTest.kt
+++ b/src/test/kotlin/org/stt/cli/MainTest.kt
@@ -17,6 +17,7 @@ import org.stt.persistence.stt.STTItemReader
 import org.stt.query.TimeTrackingItemQueries
 import org.stt.reporting.WorkingtimeItemProvider
 import org.stt.text.WorktimeCategorizer
+import org.stt.time.DurationRounder
 import java.io.*
 import java.nio.charset.StandardCharsets
 import java.time.format.DateTimeFormatter
@@ -64,7 +65,8 @@ class MainTest {
         val queries = TimeTrackingItemQueries(readerProvider, Optional.empty())
         val worktimeItemProvider = WorkingtimeItemProvider(configRoot.worktime, "")
         val categorizer = WorktimeCategorizer(configRoot.worktime)
-        val reportPrinter = ReportPrinter(queries, configRoot.cli, worktimeItemProvider, categorizer)
+        val rounder = DurationRounder()
+        val reportPrinter = ReportPrinter(queries, configRoot.cli, worktimeItemProvider, categorizer, rounder)
         val persister = STTItemPersister(sttReader, sttWriter)
         val timeFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
         val dateTimeFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT)

--- a/src/test/kotlin/org/stt/cli/ReportPrinterTest.kt
+++ b/src/test/kotlin/org/stt/cli/ReportPrinterTest.kt
@@ -17,6 +17,7 @@ import org.stt.reporting.WorkingtimeItemProvider
 import org.stt.text.ItemCategorizer
 import org.stt.text.ItemCategorizer.ItemCategory
 import org.stt.time.DateTimes
+import org.stt.time.DurationRounder
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.nio.charset.StandardCharsets
@@ -41,6 +42,9 @@ class ReportPrinterTest {
     @Mock
     private lateinit var categorizer: ItemCategorizer
 
+    @Mock
+    private lateinit var rounder: DurationRounder
+
     @Before
     fun setup() {
         MockitoAnnotations.initMocks(this)
@@ -51,8 +55,9 @@ class ReportPrinterTest {
         readFrom = Provider { itemReader }
         given(categorizer.getCategory(anyString())).willReturn(
                 ItemCategory.WORKTIME)
+        given(rounder.roundDuration(any())).willReturn(Duration.ofDays(2))
         sut = ReportPrinter(TimeTrackingItemQueries(readFrom, Optional.empty()), configuration,
-                workingtimeItemProvider, categorizer)
+                workingtimeItemProvider, categorizer, rounder)
     }
 
     @Test

--- a/src/test/kotlin/org/stt/gui/jfx/binding/ReportBindingTest.kt
+++ b/src/test/kotlin/org/stt/gui/jfx/binding/ReportBindingTest.kt
@@ -16,6 +16,7 @@ import org.stt.model.TimeTrackingItem
 import org.stt.persistence.ItemReader
 import org.stt.query.TimeTrackingItemQueries
 import org.stt.text.ItemCategorizer
+import org.stt.time.DurationRounder
 import java.time.Duration
 import java.time.LocalDate
 import java.util.*
@@ -30,6 +31,7 @@ class ReportBindingTest {
     private var sut: ReportBinding? = null
     private val reportStart = SimpleObjectProperty<LocalDate>()
     private val reportEnd = SimpleObjectProperty<LocalDate>()
+    private val rounder = DurationRounder()
 
     private var readerProvider: Provider<ItemReader>? = null
     private val itemReader = mock(ItemReader::class.java)
@@ -38,7 +40,7 @@ class ReportBindingTest {
     @Before
     fun setup() {
         readerProvider = Provider { itemReader }
-        sut = ReportBinding(reportStart, reportEnd, itemCategorizer,
+        sut = ReportBinding(reportStart, reportEnd, itemCategorizer, rounder,
                 TimeTrackingItemQueries(readerProvider!!, Optional.empty()))
     }
 


### PR DESCRIPTION
* refactored `ReportController` and `ReportPanel`
  * grouped reported times visually
  * rounded the uncovered duration
  * introduced non-effective duration to sum up break and uncovered

* add roundedDuration to `ReportingItem` and `Report`
  * added `DurationRounder` to all constructors, that internally use it to create an instance of `SummingReportGenerator`
* fixed `DurationRounder` to avoid division-by-zero
* added dependency to mockito-kotlin, to use `anyOrNull()`