### PR TITLE
Bugfix/fix edits of previous days

### DIFF
--- a/src/main/antlr/org/stt/grammar/EnglishCommands.g4
+++ b/src/main/antlr/org/stt/grammar/EnglishCommands.g4
@@ -27,7 +27,7 @@ agoFormat returns [int amount] :
 
 date: (NUMBER|DOT|MINUS|SLASH)+;
 
-dateTimeInternal: (NUMBER|DOT|MINUS|SLASH|COLON)+;
+dateTimeInternal: (NUMBER|DOT|MINUS|SLASH|COLON|COMMA)+;
 
 dateTime returns [String text]: txt=dateTimeInternal { $text = $txt.text; };
 
@@ -84,6 +84,7 @@ reportStart returns [LocalDate from_date, LocalDate to_date]:
 // WHEN ADDING TOKENS: ADD THEM to anyToken above!!
 // SYMBOLS
 COLON: ':';
+COMMA: ',';
 DOT: '.';
 MINUS: '-';
 SLASH: '/';

--- a/src/main/kotlin/org/stt/command/CommandModule.kt
+++ b/src/main/kotlin/org/stt/command/CommandModule.kt
@@ -39,7 +39,7 @@ class CommandModule {
     @Named("dateTimeFormatter")
     fun provideDateTimeFormatter(): DateTimeFormatter {
         return DateTimeFormatterBuilder()
-                .appendLocalized(FormatStyle.MEDIUM, FormatStyle.MEDIUM)
+                .appendLocalized(FormatStyle.SHORT, FormatStyle.MEDIUM)
                 .toFormatter()
     }
 

--- a/src/test/kotlin/org/stt/connector/jira/JiraClientTest.kt
+++ b/src/test/kotlin/org/stt/connector/jira/JiraClientTest.kt
@@ -1,5 +1,6 @@
 package org.stt.connector.jira
 
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import org.stt.config.JiraConfig
 
@@ -10,10 +11,9 @@ internal class JiraClientTest {
   fun testErrorHandlingOfIssueRequest() {
     val jiraConfig = JiraConfig()
     jiraConfig.jiraURI = "https://jira.atlassian.net"
-    try {
+    assertThatThrownBy {
       JiraClient("dummy", null, jiraConfig.jiraURI!!).getIssue("JRA-7")
-    } catch (e: Exception) {
-      assert(e.message.equals("Couldn't find issue JRA-7. Cause: {\"errorMessage\": \"Site temporarily unavailable\"}"))
-    }
+    }.isInstanceOf(IssueDoesNotExistException::class.java)
+      .hasMessageContainingAll("Couldn't find issue JRA-7", "\"errorMessage\": \"Site temporarily unavailable\"")
   }
 }


### PR DESCRIPTION
Fix editing of entries of previous 

* extended the grammar as DateFormatter emits texts with a comma
* switched the DateFormatter to short syntax to keep it numbers only. This
  way the grammar didn't need further changes.
  Medium style resulted in "5 Jul 2024, 12:00"

Works for `Locale.UK` and `Locale.GERMAN`. Fixing it for other locales like `Locale.US` would require changing the grammar to allow text in `dateTime`.
fixes #75